### PR TITLE
Update manifest for 0.109.x compatibility

### DIFF
--- a/custom_components/clear_grass/manifest.json
+++ b/custom_components/clear_grass/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/Cheaterdev/clear_grass-ha",
   "requirements": [
     "construct==2.9.45",
-    "python-miio==0.4.5"
+    "python-miio>=0.4.5"
   ],
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
Update requirement in manifest.json for python-miio version to enable compatibility with 0.109.x.  In 0.109, python-miio is now at version 0.5.0.1. Current requirement breaks integration with other Xiaomi MIIO devices (see https://github.com/home-assistant/core/issues/34955). Cleargrass and other Xiaomi devices may need to be removed and re-added in configuration.yaml for changes to take effect.