### PR TITLE
Add missing version key

### DIFF
--- a/custom_components/clear_grass/manifest.json
+++ b/custom_components/clear_grass/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "clear_grass",
   "name": "ClearGlass",
+  "version": "0.0.1",
   "documentation": "https://github.com/Cheaterdev/clear_grass-ha",
   "requirements": [
     "construct==2.9.45",


### PR DESCRIPTION
No 'version' key in the manifest file for custom integration 'clear_grass'.
This will not be allowed in a future version of Home Assistant.